### PR TITLE
move from URL-encoded string  to base64

### DIFF
--- a/__tests__/to_query_string.ts
+++ b/__tests__/to_query_string.ts
@@ -1,0 +1,26 @@
+import { fromQueryString, fromArray, Operators, toQueryString } from "../src";
+
+interface I {
+  foo: number;
+  bar: string;
+  baz: boolean;
+}
+
+describe("to/from query string", () => {
+  it("from string decodes to same filter", (done) => {
+    const f = fromArray<I>([
+      ["baz", Operators.equal, true],
+      ["foo", Operators.greaterThan, 1],
+      ["foo", Operators.greaterThanOrEqualTo, 1],
+      ["foo", Operators.lessThanOrEqualTo, 1],
+      ["foo", Operators.lessThan, 1],
+      ["foo", Operators.notEqual, 1],
+      ["bar", Operators.equal, "fooo"],
+      ["bar", Operators.contains, "fooo"],
+    ]);
+
+    expect(fromQueryString(toQueryString(f))).toEqual(f);
+
+    done();
+  });
+});

--- a/__tests__/to_string.ts
+++ b/__tests__/to_string.ts
@@ -24,7 +24,12 @@ describe("to string", () => {
   });
   it("more than one rule", (done) => {
     const f = addRule(
-      addRule(addRule({} as Filters<I>, "baz", Operators.equal, true), "foo", Operators.equal, 1),
+      addRule(
+        addRule({} as Filters<I>, "baz", Operators.equal, true),
+        "foo",
+        Operators.equal,
+        1
+      ),
       "bar",
       Operators.equal,
       "fooo"
@@ -34,7 +39,12 @@ describe("to string", () => {
   });
   it("more than one rule same name", (done) => {
     const f = addRule(
-      addRule(addRule({} as Filters<I>, "foo", Operators.equal, 1), "foo", Operators.equal, 2),
+      addRule(
+        addRule({} as Filters<I>, "foo", Operators.equal, 1),
+        "foo",
+        Operators.equal,
+        2
+      ),
       "bar",
       Operators.equal,
       "fooo"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barhamon/filters",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": false,
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -15,9 +15,9 @@
     "test": "jest"
   },
   "devDependencies": {
-    "typescript": "4.2.3",
+    "@types/jest": "22.2.3",
     "jest": "26.6.3",
     "ts-jest": "26.5.3",
-    "@types/jest": "22.2.3"
+    "typescript": "4.2.3"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -194,5 +194,5 @@ const filterByYearAndGenre = fromString('{"year":[[1981,2]],"genre":[["ict":6]]}
 creates new filter from url encoded string,
 usage:
 ```TS
-const filterByYearAndGenre = fromQueryString('%7B%22year%22%3A%5B%5B1981%2C2%5D%5D%2C%22genre%22%3A%5B%5B%22ict%22%2C6%5D%5D%7D')
+const filterByYearAndGenre = fromQueryString('eyJ5ZWFyIjpbWzE5ODEsMl1dLCJnZW5yZSI6W1siaWN0Iiw2XV19')
 ```

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -33,7 +33,7 @@ export enum Operators {
   lessThan = 3,
   greaterThanOrEqualTo = 4,
   lessThanOrEqualTo = 5,
-  contains = 6
+  contains = 6,
 }
 
 export function isOp(val: any): val is Operators {
@@ -158,7 +158,7 @@ export function fromString<T extends AnyDict<T>>(str: string): Filters<T> {
 }
 
 export function fromQueryString<T extends AnyDict<T>>(str: string): Filters<T> {
-  return fromString(decodeURIComponent(str));
+  return fromString(Buffer.from(str, "base64").toString("utf8"));
 }
 
 export function addRule<T extends AnyDict<T>, K extends keyof T>(
@@ -175,7 +175,15 @@ export function addRule<T extends AnyDict<T>, K extends keyof T>(
     throw new Error(
       `only string fields can be filtered by "${opToText(op)}" filter`
     );
-  } else if ([Operators.greaterThan, Operators.lessThan, Operators.greaterThanOrEqualTo, Operators.lessThanOrEqualTo].includes(op) && !isNumeric(value)) {
+  } else if (
+    [
+      Operators.greaterThan,
+      Operators.lessThan,
+      Operators.greaterThanOrEqualTo,
+      Operators.lessThanOrEqualTo,
+    ].includes(op) &&
+    !isNumeric(value)
+  ) {
     throw new Error(
       `only number fields can be filtered by "${opToText(op)}" filter`
     );
@@ -201,7 +209,7 @@ export function removeRule<T extends AnyDict<T>>(
   filter: Filters<T>,
   key: keyof T
 ): Filters<T> {
-  const {[key]: undefined, ...rest} = filter;
+  const { [key]: undefined, ...rest } = filter;
   return rest as Filters<T>;
 }
 
@@ -222,7 +230,7 @@ export function toString<T extends AnyDict<T>, K extends keyof T>(
 export function toQueryString<T extends AnyDict<T>>(
   filter: Filters<T>
 ): string {
-  return encodeURIComponent(toString(filter));
+  return Buffer.from(toString(filter)).toString("base64");
 }
 
 export function toMongoQuery<T extends AnyDict<T>>(


### PR DESCRIPTION
base64 is more space-efficient

```TS
const filterByYearAndGenre = fromArray([
  ["year", Operators.greaterThan, 1981],
  ["genre", Operators.contains, "ict"]
]);
```
filter from the above will result in this string
```TS
'{"year":[[1981,2]],"genre":[["ict":6]]}'
```

Which will be:
- URL-encoded 
'%7B%22year%22%3A%5B%5B1981%2C2%5D%5D%2C%22genre%22%3A%5B%5B%22ict%22%2C6%5D%5D%7D'
- base64
'eyJ5ZWFyIjpbWzE5ODEsMl1dLCJnZW5yZSI6W1siaWN0Iiw2XV19'
